### PR TITLE
fix: add missing GH_TOKEN

### DIFF
--- a/.github/workflows/cron-tasks.yaml
+++ b/.github/workflows/cron-tasks.yaml
@@ -42,6 +42,7 @@ jobs:
 
     - id: coverage-run
       env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PYTHONUNBUFFERED: "1"
       run: make test
 


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_missing token causes coverage-run failure in cron task_


<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?

_This PR add missing GH_TOKEN in coverage run.._


<!-- What's been changed by this PR? -->
#### What's on this PR?

* cron-tasks.yaml
