### PR TITLE
fix: resolve mixed-returns

### DIFF
--- a/src/delete_workflow_runs/run.py
+++ b/src/delete_workflow_runs/run.py
@@ -424,6 +424,7 @@ def delete_workflow_runs(count, repo, workflow_run_id):  # pragma: no cover
 
     except GithubException as e:
         print(f'❌ Failed to delete workflow run {workflow_run_id}: {e}')
+        return None
 
 
 def get_api_estimate(orphan_runs_count, delete_runs_count):


### PR DESCRIPTION
#### Issue Summary
CodeQL py/mixed-returns

> When a function contains both explicit returns (return value) and implicit returns (where code falls off the end of a function), this often indicates that a return statement has been forgotten. It is best to return an explicit return value even when returning None because this makes it easier for other developers to read your code

#### Why's this PR created?
This PR resolves CodeQL py/mixed-returns by adding a return None statement in the case where the **delete_workflow_runs** function gets an exception.
