### PR TITLE
fix: add fail-on-severity to dependency-review to detect vulnerabilities packages

### DIFF
--- a/.github/workflows/reusable-dependency-review.yaml
+++ b/.github/workflows/reusable-dependency-review.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  review:
+  review: # https://github.com/actions/dependency-review-action
     runs-on: ubuntu-latest
     steps:
 
@@ -22,3 +22,4 @@ jobs:
         license-check: false
         vulnerability-check: true
         show-openssf-scorecard: false
+        fail-on-severity: low


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?
This PR adds **fail-on-severity: low** to dependency-review action configuration.  Upon pull request, dependency review will detect any vulnerable packages with severity level "low" or higher.
