### PR TITLE
fix: fix version not changing

### DIFF
--- a/.github/workflows/reusable-codeql.yaml
+++ b/.github/workflows/reusable-codeql.yaml
@@ -34,13 +34,13 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.5
+      uses: github/codeql-action/init@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.5
+      uses: github/codeql-action/analyze@96f518a34f7a870018057716cc4d7a5c014bd61c # v3.29.10
       with:
         output: codeql-results/
 


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_upon dependabot update, codeql-action was updated to the appropriate hash but the version after the hash was not updated on v3.29.5.  It does not happen to other version._

<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?
_This PR updates codeql-action from v3.29.5 to v3.29.10_

